### PR TITLE
Disables addon when not a druid

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -3,6 +3,11 @@
 -- A addon by Insa of Venoxis inspired by https://github.com/NerdEgghead/WotLK_cat_sim by NerdEgghead
 
 ------------------------------------------------------------------------------------------------------------------------
+if IsSpellKnown(48574) ~= true then
+    print("Disabling Feral By Nerd Druids: Rake is not learned.")
+    return
+end
+
 SLASH_RELOAD1 = "/rl"
 SlashCmdList.RELOAD = ReloadUi
 
@@ -1009,7 +1014,7 @@ function FeralByNerdDruids:decideOnSpellInRotation()
     rotationData.excessEnergy = excessEnergy;
     rotationData.ripRefreshPending = ripRefreshPending;
 
-    print(rotationData.encounterTimeRemaining);
+    --print(rotationData.encounterTimeRemaining);
     spell = FeralByNerdDruids:nextSpell(rotationData)
     FeralByNerdDruids.textureList["current"]:SetTexture(GetSpellTexture(spell));
 end


### PR DESCRIPTION
very simple change that prevents the addon from continually running into errors if you don't have rake learned (ex: you're not a druid).